### PR TITLE
database.ymlを本番環境のmysqlに合わせるよう変更

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -50,5 +50,7 @@ test:
 production:
   <<: *default
   database: freemarket_sample_63d_production
-  username: freemarket_sample_63d
-  password: <%= ENV['FREEMARKET_SAMPLE_63D_DATABASE_PASSWORD'] %>
+  username: root
+  password: <%= ENV['DATABASE_PASSWORD'] %>
+  socket: /var/lib/mysql/mysql.sock
+


### PR DESCRIPTION
# what
タイトル通りです。
root, password, socketを編集

# why
自動デプロイに必要な設定のため