### PR TITLE
[ito] トップページにヘッダーとフッターを追加

### DIFF
--- a/app/views/tops/index.html.haml
+++ b/app/views/tops/index.html.haml
@@ -1,9 +1,10 @@
 %body
 
   %header
-  
+  = render "shared/header_navbar"
+
   .slider
-    = link_to do  
+    = link_to do
       %i.fas.fa-angle-left
     = link_to do
       %i.fas.fa-angle-right
@@ -53,7 +54,7 @@
         %b
           もっと見る＞
     = render partial: "tops"
-    
+
   .popularity
     %h2 人気のブランド
     %ul.item
@@ -69,7 +70,7 @@
       %li.item__tag
         = link_to do
           ナイキ
-    
+
   .item__all
 
     .new__item__title
@@ -98,9 +99,7 @@
       = link_to do
         %b
           もっと見る＞
-    = render partial: "tops"  
-    
-  .news__bar
-  %footer
+    = render partial: "tops"
 
+  = render "shared/footer"
   = render partial: "exibit_button"


### PR DESCRIPTION
# what
- トップページにヘッダーとフッターを追加しました
# why
- 作業分担により別のメンバーが作成していたヘッダーとフッターの部分テンプレートが完成したため。
# 作成したページのキャプチャ画像
[FreemarketSample63d - Gyazo](https://gyazo.com/bf13f04a052b29d131c04be57fc62c61)
