### PR TITLE
[ito] readmeに記載されているアソシエーションを修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,12 +80,12 @@
 ### Association
 - belongs_to :user_profile
 - belongs_to :category
-- belongs_to :saling_product
-- belongs_to :bought_product
-- belongs_to :sold_product
+- has_one :saling_product, dependent: :destroy
+- has_one :bought_product, dependent: :destroy
+- has_one :sold_product, dependent: :destroy
 - belongs_to :brand
-- has_many :product_images
-- has_many :comments
+- has_many :product_images, dependent: :destroy
+- has_many :comments, dependent: :destroy
 - has_one :buyer, through: :bought_product, source: :buyer
 - has_one :accepter, through: :sold_product, source: :buyer
 


### PR DESCRIPTION
# what
- readmeのみの変更です。モデルのファイルに記載されている内容に変更はありません。
- product.rbにかかれているアソシエーションとreadmeとの記載に不一致があったのを修正しました。
# why
- product.rbにかかれている方が本来の設計内容であり、readmeに書かれている方は記入ミスです。
- 記入ミスがあるreadmeを長くそのままにしておくと誤解を招くため。 