### PR TITLE
create 2 dummy migration files and add_ChangeDataPhoneNumberToUsers

### DIFF
--- a/db/migrate/20191210062309_dummy1.rb
+++ b/db/migrate/20191210062309_dummy1.rb
@@ -1,0 +1,5 @@
+class ChangeDataPhoneNumberToUsers < ActiveRecord::Migration[5.2]
+  def change
+  change_column :users, :phone_number, :string
+  end
+end

--- a/db/migrate/20191210110335_dummy2.rb
+++ b/db/migrate/20191210110335_dummy2.rb
@@ -1,0 +1,5 @@
+class ChangeDataPhoneNumberToUsers < ActiveRecord::Migration[5.2]
+  def change
+  change_column :users, :phone_number, :string
+  end
+end

--- a/db/migrate/20191212122430_change_data_phone_number_to_users.rb
+++ b/db/migrate/20191212122430_change_data_phone_number_to_users.rb
@@ -1,0 +1,5 @@
+class ChangeDataPhoneNumberToUsers < ActiveRecord::Migration[5.2]
+  def change
+  change_column :users, :phone_number, :string
+  end
+end


### PR DESCRIPTION
# what
migratonファイルの整合性をつけるために

     20191210062309  Dummy1
     20191210110335  Dummy2

というファイルを追加。

更にusersテーブルのphone_numberのデータ型をintegerからvarchar(255)に変更するmigrationファイル追加

    20191212122430  Change data phone number to users

# why
整合性をつけるため

ローカルにpullした後

rails db:version
でマイグレーションの状態を確認
のちに
rails db:migrate:status

にてDummyの部分がupになっているか確認してください。
upの場合はmigrationファイルは不要ですので

rails db:migrate:down VERSION=20191210062309
rails db:migrate:down VERSION=20191210110335

としてdownにしてからmigrationファイルを削除してください。

rails db:migrateでデータ型を変えるのもお忘れなく