### PR TITLE
Basic認証の設定

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,12 @@
 class ApplicationController < ActionController::Base
+  before_action :basic_auth
+  protect_from_forgery with: :exception
+
+  private
+  def basic_auth
+    authenticate_or_request_with_http_basic do |username, password|
+      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
+      # username == 'admin' && password == '2222'
+    end
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,12 +1,15 @@
 class ApplicationController < ActionController::Base
-  before_action :basic_auth
+  before_action :basic_auth, if: :production?
   protect_from_forgery with: :exception
 
   private
+  def production?
+    Rails.env.production?
+  end
+
   def basic_auth
     authenticate_or_request_with_http_basic do |username, password|
       username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
-      # username == 'admin' && password == '2222'
     end
   end
 end

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -64,4 +64,3 @@
 #本番環境用セッティング
 
 server '3.115.205.148', user: 'ec2-user', roles: %w{app db web}
-

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -64,3 +64,7 @@
 #本番環境用セッティング
 
 server '3.115.205.148', user: 'ec2-user', roles: %w{app db web}
+
+#Unicronに現在の環境を本番環境として認識させる。BASIC認証用に記述
+set :rails_env, "production"
+set :unicorn_rack_env, "production"


### PR DESCRIPTION
# what
アプリケーションコントローラに記述し本番環境でのみ認証をかけるよう設定
環境変数をEC2上にあげてます。credentials.ymlは使いません。

# why
アクセス権限を設定する為！