### PR TITLE
[ito]マイページの表示崩れの修正、トップページのリンクをマイページへのリンクに変更

### DIFF
--- a/app/assets/stylesheets/product.scss
+++ b/app/assets/stylesheets/product.scss
@@ -10,10 +10,10 @@
 }
 
 .main {
-  position: relative;
-  margin: 0, auto;
-  margin: 0px auto;
-  width: 700px;
+  // position: relative;
+  // margin: 0, auto;
+  // margin: 0px auto;
+  // width: 700px;
   .section {
   }
   &__conteiner {

--- a/app/views/shared/_header_navbar.html.haml
+++ b/app/views/shared/_header_navbar.html.haml
@@ -36,4 +36,7 @@
               = image_tag 'mypage/boy_01.png', alt: 'user_icon', height: '32', width: '32'
               %span #{current_user.user_profile.nickname}
           - else
-            = link_to "新規登録", new_signup_path
+            = link_to "ログイン", new_user_session_path
+        %li.pc-header__inner__navbar__menu-right__item
+          - unless user_signed_in?
+            = link_to "新規会員登録", new_signup_path

--- a/app/views/shared/_header_navbar.html.haml
+++ b/app/views/shared/_header_navbar.html.haml
@@ -32,7 +32,7 @@
             %span やることリスト
         %li.pc-header__inner__navbar__menu-right__item
           - if user_signed_in?
-            = link_to destroy_user_session_path, method: :delete do
+            = link_to user_accounts_path do
               = image_tag 'mypage/boy_01.png', alt: 'user_icon', height: '32', width: '32'
               %span #{current_user.user_profile.nickname}
           - else

--- a/app/views/single/_single-header.html.haml
+++ b/app/views/single/_single-header.html.haml
@@ -2,4 +2,5 @@
   %h1
     %figure.single-header__icon
       %figure.single-header__icon-image
-        = image_tag("fmarket_logo_red.svg")
+        = link_to root_path do
+          = image_tag("fmarket_logo_red.svg")

--- a/app/views/tops/_logoutpage.html.haml
+++ b/app/views/tops/_logoutpage.html.haml
@@ -1,4 +1,4 @@
 .main__inner__body
   .mypage__logout__container
-    = link_to "", class: "logout__button" do
+    = link_to destroy_user_session_path, method: :delete, class: "logout__button" do
       ログアウト

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   root to: "tops#index"
   resources :userprofile, only: [:edit]
   resources :cwavetests, only: [:index, :create, :new]
-  resources :user_accounts, only: [:index], path: "mypage" do
+  resources :user_accounts, only: [:index], path: "/mypage" do
     collection do
       get :logout
     end


### PR DESCRIPTION
# what
- マイページの表示くずれを解消しました
- トップページにマイページへのリンクを付けました。
- マイページのログアウトボタンの遷移先からログアウトできるようにしました。
# why
- マイページへのリンクがトップページにないのは不便だから
- ログアウトボタンはログアウトページにあるのが自然だから。