### PR TITLE
[ito] 商品出品ページの画像プレビューの表示位置をサイズによらず揃うように修正

### DIFF
--- a/app/assets/javascripts/products/image_previewer.js
+++ b/app/assets/javascripts/products/image_previewer.js
@@ -18,7 +18,7 @@ $(document).on("turbolinks:load", function() {
     var template = `
     <li class="exhibit-center__main__form-section__images__preview__item" data-image-id="${image_id}">
       <div class="exhibit-center__main__form-section__images__preview__item__image">
-        <img alt="${alt}" src="${src}" width="110">
+        <img alt="${alt}" src="${src}">
       </div>
       <div class="exhibit-center__main__form-section__images__preview__item__button-delete">
         <span>削除</span>

--- a/app/assets/stylesheets/modules/_product_exhibit.scss
+++ b/app/assets/stylesheets/modules/_product_exhibit.scss
@@ -20,12 +20,20 @@
         height: 150px;
         &__preview {
           display: flex;
-          padding: 10px 15px;
+          padding: 5px 15px;
           &__item {
             width: 110px;
             text-align: center;
+            display: flex;
+            flex-direction: column;
+            justify-content: space-between;
             &:not(:first-of-type) {
               margin-left: 10px;
+            }
+            &__image {
+              flex-grow: 1;
+              display: flex;
+              align-items: center;
             }
             &__button-delete {
               color: $mypage-ultramarine;

--- a/app/assets/stylesheets/modules/_product_exhibit.scss
+++ b/app/assets/stylesheets/modules/_product_exhibit.scss
@@ -34,9 +34,15 @@
               flex-grow: 1;
               display: flex;
               align-items: center;
+              img {
+                max-width: 110px;
+                max-height: 110px;
+              }
             }
             &__button-delete {
               color: $mypage-ultramarine;
+              height: 18px;
+              line-height: 18px;
               &:hover {
                 cursor: pointer;
               }

--- a/app/views/products/_product_images_preview_item.html.haml
+++ b/app/views/products/_product_images_preview_item.html.haml
@@ -1,6 +1,5 @@
 %li.exhibit-center__main__form-section__images__preview__item{ data: {"image-id": image.id} }
   .exhibit-center__main__form-section__images__preview__item__image
     = image_tag image.image_url, alt: image.image.identifier
-    -#  , width: '10'
   .exhibit-center__main__form-section__images__preview__item__button-delete
     %span 削除

--- a/app/views/products/_product_images_preview_item.html.haml
+++ b/app/views/products/_product_images_preview_item.html.haml
@@ -1,5 +1,6 @@
 %li.exhibit-center__main__form-section__images__preview__item{ data: {"image-id": image.id} }
   .exhibit-center__main__form-section__images__preview__item__image
-    = image_tag image.image_url, alt: 'jcb', width: '110'
+    = image_tag image.image_url, alt: image.image.identifier
+    -#  , width: '10'
   .exhibit-center__main__form-section__images__preview__item__button-delete
     %span 削除


### PR DESCRIPTION
# what
- 商品出品ページにて、複数の画像が投稿され、サイズが統一されていない場合、プレビュー画像の表示位置が不揃いになってしまっていた不具合を修正しました。
# why
- プレビュー表示が不格好だとユーザーからの印象が悪くなるため。
# 修正点を示すキャプチャ画像
- 修正前： [FreemarketSample63d - Gyazo](https://gyazo.com/3803e8c5aa030c71fd77d6a918be47f3)
- 修正後：[FreemarketSample63d - Gyazo](https://gyazo.com/994c363a2fc34f5a5890b1534fca6194)
